### PR TITLE
stop using root

### DIFF
--- a/hiccup/cli.py
+++ b/hiccup/cli.py
@@ -62,15 +62,13 @@ def clean(ctx, deep):
 
 @cli.command()
 @click.option("-c", "--clean", is_flag=True)
-@click.argument("target_dir", nargs=1, default="./", type=Path)
 @click.pass_context
-def run(ctx, clean, target_dir):
+def run(ctx, clean):
     config = HiccupConfig(ctx.obj["config_filename"])
     task_ctx = {"__globals": config.globals, "__root": ""}
     if clean:
         logging.info("Running tasks")
         TaskList(tasks=config.clean_tasks, ctx=task_ctx).run_tasks()
-    task_ctx["__root"] = target_dir
     task_list = TaskList(tasks=config.run_tasks, ctx=task_ctx)
     logging.info("Running tasks")
     task_list.run_tasks()

--- a/hiccup/functions.py
+++ b/hiccup/functions.py
@@ -51,10 +51,16 @@ def parse_markdown_with_template(filepath: Path, ctx: dict, template_dir: str):
 
 
 def write_text_to_file(
-    filepath: Path, ctx: dict, text: str, out_dir: str, ext: Optional[str] = None
+    filepath: Path,
+    ctx: dict,
+    text: str,
+    out_dir: str,
+    ext: Optional[str] = None,
+    relative_to: Optional[str] = None,
 ):
-    rel_filepath = filepath.relative_to(ctx["__root"])
-    new_filepath = Path(out_dir) / rel_filepath
+    if relative_to is not None:
+        filepath = filepath.relative_to(relative_to)
+    new_filepath = Path(out_dir) / filepath
     new_filepath.parent.mkdir(parents=True, exist_ok=True)
     if ext is not None:
         new_filepath = new_filepath.with_suffix(ext)
@@ -63,10 +69,13 @@ def write_text_to_file(
     return ctx
 
 
-def copy_files(filepath: Path, ctx: dict, out_dir: str):
+def copy_files(
+    filepath: Path, ctx: dict, out_dir: str, relative_to: Optional[str] = None
+):
     out_dir = Path(out_dir)
-    rel_filepath = filepath.relative_to(ctx["__root"])
-    new_filepath = Path(out_dir) / rel_filepath
+    if relative_to is not None:
+        filepath = filepath.relative_to(relative_to)
+    new_filepath = Path(out_dir) / filepath
     if filepath.is_file():
         new_filepath.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(filepath, new_filepath)


### PR DESCRIPTION
fixes #3 

i'll leave `ctx["__root"]` around for now because it seems conceptually like it could be useful, but i removed the `target_dir` attribute from `run` and stopped using `__root` in the functions.

situations where file operations require a notion of relative paths are now handled with a `relative_to` argument.